### PR TITLE
add TF file linting to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    paths:
+      - '.github/workflows/tests.yml'
+      - 'examples/**'
+      - 'modules/**'
+
+jobs:
+  lint-terraform-files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set Terraform
+        uses: hashicorp/setup-terraform@v3
+      - name: Terraform fmt
+        run: terraform fmt -check -recursive
+      - name: Terraform Validate
+        run: terraform validate -no-tests


### PR DESCRIPTION
Used terraform in CI directly as setting up golang and then taskfile takes more time than it's worth, IMO