### PR TITLE
add missing note field from service resource

### DIFF
--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -6,6 +6,7 @@ resource "opslevel_service" "this" {
   language                      = var.language
   lifecycle_alias               = var.lifecycle_alias
   name                          = var.name
+  note                          = var.note
   owner                         = var.owner
   preferred_api_document_source = var.preferred_api_document_source
   product                       = var.product

--- a/modules/service/variables.tf
+++ b/modules/service/variables.tf
@@ -40,6 +40,12 @@ variable "name" {
   description = "The display name of the service."
 }
 
+variable "note" {
+  type        = string
+  description = "Additional information about the service."
+  default     = null
+}
+
 variable "owner" {
   type        = string
   description = "The team that owns the service. ID or Alias may be used."
@@ -100,3 +106,4 @@ variable "properties" {
   description = "A map of property definition alias to the properties json value representation to store custom data about the service."
   default     = {}
 }
+


### PR DESCRIPTION
Add missing `note` field to `opslevel_service` resource in `service` module - this field is optional