### PR TITLE
localize rubric_category and rubric_level to checks

### DIFF
--- a/modules/check/alert_source_usage/main.tf
+++ b/modules/check/alert_source_usage/main.tf
@@ -3,23 +3,22 @@ resource "opslevel_check_alert_source_usage" "this" {
   alert_type           = var.alert_type
 
   # -- check base fields --
-  category  = local.rubric_category
+  category  = module.category.this
   enable_on = var.enable_on
   enabled   = var.enabled
   filter    = var.filter
-  level     = local.rubric_level
+  level     = module.level.this
   name      = var.name
   notes     = var.notes
   owner     = var.owner
 }
 
-locals {
-  rubric_category = var.category == null ? null : startswith(var.category, "Z2lkOi8v") ? var.category : element([
-    for category in data.opslevel_rubric_categories.all.rubric_categories :
-    category.id if category.alias == var.category
-  ], 0)
-  rubric_level = var.level == null ? null : startswith(var.level, "Z2lkOi8v") ? var.level : element([
-    for level in data.opslevel_rubric_levels.all.rubric_levels :
-    level.id if level.alias == var.level
-  ], 0)
+module "category" {
+  source          = "../../rubric_category/data"
+  rubric_category = var.category
+}
+
+module "level" {
+  source       = "../../rubric_level/data"
+  rubric_level = var.level
 }

--- a/modules/check/alert_source_usage/main.tf
+++ b/modules/check/alert_source_usage/main.tf
@@ -3,22 +3,23 @@ resource "opslevel_check_alert_source_usage" "this" {
   alert_type           = var.alert_type
 
   # -- check base fields --
-  category  = module.category.this
+  category  = local.rubric_category
   enable_on = var.enable_on
   enabled   = var.enabled
   filter    = var.filter
-  level     = module.level.this
+  level     = local.rubric_level
   name      = var.name
   notes     = var.notes
   owner     = var.owner
 }
 
-module "category" {
-  source          = "../../rubric_category"
-  rubric_category = var.category
-}
-
-module "level" {
-  source       = "../../rubric_level"
-  rubric_level = var.level
+locals {
+  rubric_category = var.category == null ? null : startswith(var.category, "Z2lkOi8v") ? var.category : element([
+    for category in data.opslevel_rubric_categories.all.rubric_categories :
+    category.id if category.alias == var.category
+  ], 0)
+  rubric_level = var.level == null ? null : startswith(var.level, "Z2lkOi8v") ? var.level : element([
+    for level in data.opslevel_rubric_levels.all.rubric_levels :
+    level.id if level.alias == var.level
+  ], 0)
 }

--- a/modules/check/base_variables.tf
+++ b/modules/check/base_variables.tf
@@ -42,14 +42,3 @@ variable "owner" {
   description = "The id of the team that owns the check."
   default     = null
 }
-
-locals {
-  rubric_category = var.category == null ? null : startswith(var.category, "Z2lkOi8v") ? var.category : element([
-    for category in data.opslevel_rubric_categories.all.rubric_categories :
-    category.id if category.alias == var.category
-  ], 0)
-  rubric_level = var.level == null ? null : startswith(var.level, "Z2lkOi8v") ? var.level : element([
-    for level in data.opslevel_rubric_levels.all.rubric_levels :
-    level.id if level.alias == var.level
-  ], 0)
-}

--- a/modules/check/base_variables.tf
+++ b/modules/check/base_variables.tf
@@ -42,3 +42,14 @@ variable "owner" {
   description = "The id of the team that owns the check."
   default     = null
 }
+
+locals {
+  rubric_category = var.category == null ? null : startswith(var.category, "Z2lkOi8v") ? var.category : element([
+    for category in data.opslevel_rubric_categories.all.rubric_categories :
+    category.id if category.alias == var.category
+  ], 0)
+  rubric_level = var.level == null ? null : startswith(var.level, "Z2lkOi8v") ? var.level : element([
+    for level in data.opslevel_rubric_levels.all.rubric_levels :
+    level.id if level.alias == var.level
+  ], 0)
+}

--- a/modules/check/git_branch_protection/main.tf
+++ b/modules/check/git_branch_protection/main.tf
@@ -1,21 +1,20 @@
 resource "opslevel_check_git_branch_protection" "this" {
-  category  = local.rubric_category
+  category  = module.category.this
   enable_on = var.enable_on
   enabled   = var.enabled
   filter    = var.filter
-  level     = local.rubric_level
+  level     = module.level.this
   name      = var.name
   notes     = var.notes
   owner     = var.owner
 }
 
-locals {
-  rubric_category = var.category == null ? null : startswith(var.category, "Z2lkOi8v") ? var.category : element([
-    for category in data.opslevel_rubric_categories.all.rubric_categories :
-    category.id if category.alias == var.category
-  ], 0)
-  rubric_level = var.level == null ? null : startswith(var.level, "Z2lkOi8v") ? var.level : element([
-    for level in data.opslevel_rubric_levels.all.rubric_levels :
-    level.id if level.alias == var.level
-  ], 0)
+module "category" {
+  source          = "../../rubric_category/data"
+  rubric_category = var.category
+}
+
+module "level" {
+  source       = "../../rubric_level/data"
+  rubric_level = var.level
 }

--- a/modules/check/git_branch_protection/main.tf
+++ b/modules/check/git_branch_protection/main.tf
@@ -1,20 +1,21 @@
 resource "opslevel_check_git_branch_protection" "this" {
-  category  = module.category.this
+  category  = local.rubric_category
   enable_on = var.enable_on
   enabled   = var.enabled
   filter    = var.filter
-  level     = module.level.this
+  level     = local.rubric_level
   name      = var.name
   notes     = var.notes
   owner     = var.owner
 }
 
-module "category" {
-  source          = "../../rubric_category"
-  rubric_category = var.category
-}
-
-module "level" {
-  source       = "../../rubric_level"
-  rubric_level = var.level
+locals {
+  rubric_category = var.category == null ? null : startswith(var.category, "Z2lkOi8v") ? var.category : element([
+    for category in data.opslevel_rubric_categories.all.rubric_categories :
+    category.id if category.alias == var.category
+  ], 0)
+  rubric_level = var.level == null ? null : startswith(var.level, "Z2lkOi8v") ? var.level : element([
+    for level in data.opslevel_rubric_levels.all.rubric_levels :
+    level.id if level.alias == var.level
+  ], 0)
 }

--- a/modules/check/has_documentation/main.tf
+++ b/modules/check/has_documentation/main.tf
@@ -3,23 +3,22 @@ resource "opslevel_check_has_documentation" "this" {
   document_subtype = var.document_subtype
 
   # -- check base fields --
-  category  = local.rubric_category
+  category  = module.category.this
   enable_on = var.enable_on
   enabled   = var.enabled
   filter    = var.filter
-  level     = local.rubric_level
+  level     = module.level.this
   name      = var.name
   notes     = var.notes
   owner     = var.owner
 }
 
-locals {
-  rubric_category = var.category == null ? null : startswith(var.category, "Z2lkOi8v") ? var.category : element([
-    for category in data.opslevel_rubric_categories.all.rubric_categories :
-    category.id if category.alias == var.category
-  ], 0)
-  rubric_level = var.level == null ? null : startswith(var.level, "Z2lkOi8v") ? var.level : element([
-    for level in data.opslevel_rubric_levels.all.rubric_levels :
-    level.id if level.alias == var.level
-  ], 0)
+module "category" {
+  source          = "../../rubric_category/data"
+  rubric_category = var.category
+}
+
+module "level" {
+  source       = "../../rubric_level/data"
+  rubric_level = var.level
 }

--- a/modules/check/has_documentation/main.tf
+++ b/modules/check/has_documentation/main.tf
@@ -3,22 +3,23 @@ resource "opslevel_check_has_documentation" "this" {
   document_subtype = var.document_subtype
 
   # -- check base fields --
-  category  = module.category.this
+  category  = local.rubric_category
   enable_on = var.enable_on
   enabled   = var.enabled
   filter    = var.filter
-  level     = module.level.this
+  level     = local.rubric_level
   name      = var.name
   notes     = var.notes
   owner     = var.owner
 }
 
-module "category" {
-  source          = "../../rubric_category"
-  rubric_category = var.category
-}
-
-module "level" {
-  source       = "../../rubric_level"
-  rubric_level = var.level
+locals {
+  rubric_category = var.category == null ? null : startswith(var.category, "Z2lkOi8v") ? var.category : element([
+    for category in data.opslevel_rubric_categories.all.rubric_categories :
+    category.id if category.alias == var.category
+  ], 0)
+  rubric_level = var.level == null ? null : startswith(var.level, "Z2lkOi8v") ? var.level : element([
+    for level in data.opslevel_rubric_levels.all.rubric_levels :
+    level.id if level.alias == var.level
+  ], 0)
 }

--- a/modules/check/has_recent_deploy/main.tf
+++ b/modules/check/has_recent_deploy/main.tf
@@ -2,22 +2,23 @@ resource "opslevel_check_has_recent_deploy" "this" {
   days = var.days
 
   # -- check base fields --
-  category  = module.category.this
+  category  = local.rubric_category
   enable_on = var.enable_on
   enabled   = var.enabled
   filter    = var.filter
-  level     = module.level.this
+  level     = local.rubric_level
   name      = var.name
   notes     = var.notes
   owner     = var.owner
 }
 
-module "category" {
-  source          = "../../rubric_category"
-  rubric_category = var.category
-}
-
-module "level" {
-  source       = "../../rubric_level"
-  rubric_level = var.level
+locals {
+  rubric_category = var.category == null ? null : startswith(var.category, "Z2lkOi8v") ? var.category : element([
+    for category in data.opslevel_rubric_categories.all.rubric_categories :
+    category.id if category.alias == var.category
+  ], 0)
+  rubric_level = var.level == null ? null : startswith(var.level, "Z2lkOi8v") ? var.level : element([
+    for level in data.opslevel_rubric_levels.all.rubric_levels :
+    level.id if level.alias == var.level
+  ], 0)
 }

--- a/modules/check/has_recent_deploy/main.tf
+++ b/modules/check/has_recent_deploy/main.tf
@@ -2,23 +2,22 @@ resource "opslevel_check_has_recent_deploy" "this" {
   days = var.days
 
   # -- check base fields --
-  category  = local.rubric_category
+  category  = module.category.this
   enable_on = var.enable_on
   enabled   = var.enabled
   filter    = var.filter
-  level     = local.rubric_level
+  level     = module.level.this
   name      = var.name
   notes     = var.notes
   owner     = var.owner
 }
 
-locals {
-  rubric_category = var.category == null ? null : startswith(var.category, "Z2lkOi8v") ? var.category : element([
-    for category in data.opslevel_rubric_categories.all.rubric_categories :
-    category.id if category.alias == var.category
-  ], 0)
-  rubric_level = var.level == null ? null : startswith(var.level, "Z2lkOi8v") ? var.level : element([
-    for level in data.opslevel_rubric_levels.all.rubric_levels :
-    level.id if level.alias == var.level
-  ], 0)
+module "category" {
+  source          = "../../rubric_category/data"
+  rubric_category = var.category
+}
+
+module "level" {
+  source       = "../../rubric_level/data"
+  rubric_level = var.level
 }

--- a/modules/check/manual/main.tf
+++ b/modules/check/manual/main.tf
@@ -1,11 +1,11 @@
 resource "opslevel_check_manual" "this" {
-  name      = var.name
-  category  = local.rubric_category
-  level     = local.rubric_level
+  category  = module.category.this
   enable_on = var.enable_on
   enabled   = var.enabled
   filter    = var.filter
+  level     = module.level.this
   owner     = var.owner
+  name      = var.name
   notes     = var.notes
 
   update_frequency        = var.update_frequency
@@ -19,13 +19,12 @@ resource "opslevel_check_manual" "this" {
   }
 }
 
-locals {
-  rubric_category = var.category == null ? null : startswith(var.category, "Z2lkOi8v") ? var.category : element([
-    for category in data.opslevel_rubric_categories.all.rubric_categories :
-    category.id if category.alias == var.category
-  ], 0)
-  rubric_level = var.level == null ? null : startswith(var.level, "Z2lkOi8v") ? var.level : element([
-    for level in data.opslevel_rubric_levels.all.rubric_levels :
-    level.id if level.alias == var.level
-  ], 0)
+module "category" {
+  source          = "../../rubric_category/data"
+  rubric_category = var.category
+}
+
+module "level" {
+  source       = "../../rubric_level/data"
+  rubric_level = var.level
 }

--- a/modules/check/manual/main.tf
+++ b/modules/check/manual/main.tf
@@ -1,7 +1,7 @@
 resource "opslevel_check_manual" "this" {
   name      = var.name
-  category  = module.category.this
-  level     = module.level.this
+  category  = local.rubric_category
+  level     = local.rubric_level
   enable_on = var.enable_on
   enabled   = var.enabled
   filter    = var.filter
@@ -19,12 +19,13 @@ resource "opslevel_check_manual" "this" {
   }
 }
 
-module "category" {
-  source          = "../../rubric_category"
-  rubric_category = var.category
-}
-
-module "level" {
-  source       = "../../rubric_level"
-  rubric_level = var.level
+locals {
+  rubric_category = var.category == null ? null : startswith(var.category, "Z2lkOi8v") ? var.category : element([
+    for category in data.opslevel_rubric_categories.all.rubric_categories :
+    category.id if category.alias == var.category
+  ], 0)
+  rubric_level = var.level == null ? null : startswith(var.level, "Z2lkOi8v") ? var.level : element([
+    for level in data.opslevel_rubric_levels.all.rubric_levels :
+    level.id if level.alias == var.level
+  ], 0)
 }

--- a/modules/check/package_version/main.tf
+++ b/modules/check/package_version/main.tf
@@ -1,9 +1,9 @@
 resource "opslevel_check_package_version" "this" {
-  category  = module.category.this
+  category  = local.rubric_category
   filter    = var.filter
   enable_on = var.enable_on
   enabled   = var.enabled
-  level     = module.level.this
+  level     = local.rubric_level
   name      = var.name
   notes     = var.notes
   owner     = var.owner
@@ -16,12 +16,13 @@ resource "opslevel_check_package_version" "this" {
   version_constraint_predicate = var.version_constraint_predicate
 }
 
-module "category" {
-  source          = "../../rubric_category"
-  rubric_category = var.category
-}
-
-module "level" {
-  source       = "../../rubric_level"
-  rubric_level = var.level
+locals {
+  rubric_category = var.category == null ? null : startswith(var.category, "Z2lkOi8v") ? var.category : element([
+    for category in data.opslevel_rubric_categories.all.rubric_categories :
+    category.id if category.alias == var.category
+  ], 0)
+  rubric_level = var.level == null ? null : startswith(var.level, "Z2lkOi8v") ? var.level : element([
+    for level in data.opslevel_rubric_levels.all.rubric_levels :
+    level.id if level.alias == var.level
+  ], 0)
 }

--- a/modules/check/package_version/main.tf
+++ b/modules/check/package_version/main.tf
@@ -1,9 +1,9 @@
 resource "opslevel_check_package_version" "this" {
-  category  = local.rubric_category
-  filter    = var.filter
+  category  = module.category.this
   enable_on = var.enable_on
   enabled   = var.enabled
-  level     = local.rubric_level
+  filter    = var.filter
+  level     = module.level.this
   name      = var.name
   notes     = var.notes
   owner     = var.owner
@@ -16,13 +16,12 @@ resource "opslevel_check_package_version" "this" {
   version_constraint_predicate = var.version_constraint_predicate
 }
 
-locals {
-  rubric_category = var.category == null ? null : startswith(var.category, "Z2lkOi8v") ? var.category : element([
-    for category in data.opslevel_rubric_categories.all.rubric_categories :
-    category.id if category.alias == var.category
-  ], 0)
-  rubric_level = var.level == null ? null : startswith(var.level, "Z2lkOi8v") ? var.level : element([
-    for level in data.opslevel_rubric_levels.all.rubric_levels :
-    level.id if level.alias == var.level
-  ], 0)
+module "category" {
+  source          = "../../rubric_category/data"
+  rubric_category = var.category
+}
+
+module "level" {
+  source       = "../../rubric_level/data"
+  rubric_level = var.level
 }

--- a/modules/check/service_configuration/main.tf
+++ b/modules/check/service_configuration/main.tf
@@ -1,21 +1,20 @@
 resource "opslevel_check_service_configuration" "this" {
-  category  = local.rubric_category
+  category  = module.category.this
   enable_on = var.enable_on
   enabled   = var.enabled
   filter    = var.filter
-  level     = local.rubric_level
+  level     = module.level.this
   name      = var.name
   notes     = var.notes
   owner     = var.owner
 }
 
-locals {
-  rubric_category = var.category == null ? null : startswith(var.category, "Z2lkOi8v") ? var.category : element([
-    for category in data.opslevel_rubric_categories.all.rubric_categories :
-    category.id if category.alias == var.category
-  ], 0)
-  rubric_level = var.level == null ? null : startswith(var.level, "Z2lkOi8v") ? var.level : element([
-    for level in data.opslevel_rubric_levels.all.rubric_levels :
-    level.id if level.alias == var.level
-  ], 0)
+module "category" {
+  source          = "../../rubric_category/data"
+  rubric_category = var.category
+}
+
+module "level" {
+  source       = "../../rubric_level/data"
+  rubric_level = var.level
 }

--- a/modules/check/service_configuration/main.tf
+++ b/modules/check/service_configuration/main.tf
@@ -1,20 +1,21 @@
 resource "opslevel_check_service_configuration" "this" {
-  category  = module.category.this
+  category  = local.rubric_category
   enable_on = var.enable_on
   enabled   = var.enabled
   filter    = var.filter
-  level     = module.level.this
+  level     = local.rubric_level
   name      = var.name
   notes     = var.notes
   owner     = var.owner
 }
 
-module "category" {
-  source          = "../../rubric_category"
-  rubric_category = var.category
-}
-
-module "level" {
-  source       = "../../rubric_level"
-  rubric_level = var.level
+locals {
+  rubric_category = var.category == null ? null : startswith(var.category, "Z2lkOi8v") ? var.category : element([
+    for category in data.opslevel_rubric_categories.all.rubric_categories :
+    category.id if category.alias == var.category
+  ], 0)
+  rubric_level = var.level == null ? null : startswith(var.level, "Z2lkOi8v") ? var.level : element([
+    for level in data.opslevel_rubric_levels.all.rubric_levels :
+    level.id if level.alias == var.level
+  ], 0)
 }

--- a/modules/check/service_dependency/main.tf
+++ b/modules/check/service_dependency/main.tf
@@ -1,21 +1,20 @@
 resource "opslevel_check_service_dependency" "this" {
-  category  = local.rubric_category
+  category  = module.category.this
   enable_on = var.enable_on
   enabled   = var.enabled
   filter    = var.filter
-  level     = local.rubric_level
+  level     = module.level.this
   name      = var.name
   notes     = var.notes
   owner     = var.owner
 }
 
-locals {
-  rubric_category = var.category == null ? null : startswith(var.category, "Z2lkOi8v") ? var.category : element([
-    for category in data.opslevel_rubric_categories.all.rubric_categories :
-    category.id if category.alias == var.category
-  ], 0)
-  rubric_level = var.level == null ? null : startswith(var.level, "Z2lkOi8v") ? var.level : element([
-    for level in data.opslevel_rubric_levels.all.rubric_levels :
-    level.id if level.alias == var.level
-  ], 0)
+module "category" {
+  source          = "../../rubric_category/data"
+  rubric_category = var.category
+}
+
+module "level" {
+  source       = "../../rubric_level/data"
+  rubric_level = var.level
 }

--- a/modules/check/service_dependency/main.tf
+++ b/modules/check/service_dependency/main.tf
@@ -1,20 +1,21 @@
 resource "opslevel_check_service_dependency" "this" {
-  category  = module.category.this
+  category  = local.rubric_category
   enable_on = var.enable_on
   enabled   = var.enabled
   filter    = var.filter
-  level     = module.level.this
+  level     = local.rubric_level
   name      = var.name
   notes     = var.notes
   owner     = var.owner
 }
 
-module "category" {
-  source          = "../../rubric_category"
-  rubric_category = var.category
-}
-
-module "level" {
-  source       = "../../rubric_level"
-  rubric_level = var.level
+locals {
+  rubric_category = var.category == null ? null : startswith(var.category, "Z2lkOi8v") ? var.category : element([
+    for category in data.opslevel_rubric_categories.all.rubric_categories :
+    category.id if category.alias == var.category
+  ], 0)
+  rubric_level = var.level == null ? null : startswith(var.level, "Z2lkOi8v") ? var.level : element([
+    for level in data.opslevel_rubric_levels.all.rubric_levels :
+    level.id if level.alias == var.level
+  ], 0)
 }

--- a/modules/check/service_ownership/main.tf
+++ b/modules/check/service_ownership/main.tf
@@ -5,22 +5,23 @@ resource "opslevel_check_service_ownership" "this" {
   tag_predicate          = var.tag_predicate
 
   # -- check base fields --
-  category  = module.category.this
+  category  = local.rubric_category
   enable_on = var.enable_on
   enabled   = var.enabled
   filter    = var.filter
-  level     = module.level.this
+  level     = local.rubric_level
   name      = var.name
   notes     = var.notes
   owner     = var.owner
 }
 
-module "category" {
-  source          = "../../rubric_category"
-  rubric_category = var.category
-}
-
-module "level" {
-  source       = "../../rubric_level"
-  rubric_level = var.level
+locals {
+  rubric_category = var.category == null ? null : startswith(var.category, "Z2lkOi8v") ? var.category : element([
+    for category in data.opslevel_rubric_categories.all.rubric_categories :
+    category.id if category.alias == var.category
+  ], 0)
+  rubric_level = var.level == null ? null : startswith(var.level, "Z2lkOi8v") ? var.level : element([
+    for level in data.opslevel_rubric_levels.all.rubric_levels :
+    level.id if level.alias == var.level
+  ], 0)
 }

--- a/modules/check/service_ownership/main.tf
+++ b/modules/check/service_ownership/main.tf
@@ -5,23 +5,22 @@ resource "opslevel_check_service_ownership" "this" {
   tag_predicate          = var.tag_predicate
 
   # -- check base fields --
-  category  = local.rubric_category
+  category  = module.category.this
   enable_on = var.enable_on
   enabled   = var.enabled
   filter    = var.filter
-  level     = local.rubric_level
+  level     = module.level.this
   name      = var.name
   notes     = var.notes
   owner     = var.owner
 }
 
-locals {
-  rubric_category = var.category == null ? null : startswith(var.category, "Z2lkOi8v") ? var.category : element([
-    for category in data.opslevel_rubric_categories.all.rubric_categories :
-    category.id if category.alias == var.category
-  ], 0)
-  rubric_level = var.level == null ? null : startswith(var.level, "Z2lkOi8v") ? var.level : element([
-    for level in data.opslevel_rubric_levels.all.rubric_levels :
-    level.id if level.alias == var.level
-  ], 0)
+module "category" {
+  source          = "../../rubric_category/data"
+  rubric_category = var.category
+}
+
+module "level" {
+  source       = "../../rubric_level/data"
+  rubric_level = var.level
 }

--- a/modules/check/service_property/main.tf
+++ b/modules/check/service_property/main.tf
@@ -3,23 +3,22 @@ resource "opslevel_check_service_property" "this" {
   predicate = var.predicate
 
   # -- check base fields --
-  category  = local.rubric_category
+  category  = module.category.this
   enable_on = var.enable_on
   enabled   = var.enabled
   filter    = var.filter
-  level     = local.rubric_level
+  level     = module.level.this
   name      = var.name
   notes     = var.notes
   owner     = var.owner
 }
 
-locals {
-  rubric_category = var.category == null ? null : startswith(var.category, "Z2lkOi8v") ? var.category : element([
-    for category in data.opslevel_rubric_categories.all.rubric_categories :
-    category.id if category.alias == var.category
-  ], 0)
-  rubric_level = var.level == null ? null : startswith(var.level, "Z2lkOi8v") ? var.level : element([
-    for level in data.opslevel_rubric_levels.all.rubric_levels :
-    level.id if level.alias == var.level
-  ], 0)
+module "category" {
+  source          = "../../rubric_category/data"
+  rubric_category = var.category
+}
+
+module "level" {
+  source       = "../../rubric_level/data"
+  rubric_level = var.level
 }

--- a/modules/check/service_property/main.tf
+++ b/modules/check/service_property/main.tf
@@ -3,22 +3,23 @@ resource "opslevel_check_service_property" "this" {
   predicate = var.predicate
 
   # -- check base fields --
-  category  = module.category.this
+  category  = local.rubric_category
   enable_on = var.enable_on
   enabled   = var.enabled
   filter    = var.filter
-  level     = module.level.this
+  level     = local.rubric_level
   name      = var.name
   notes     = var.notes
   owner     = var.owner
 }
 
-module "category" {
-  source          = "../../rubric_category"
-  rubric_category = var.category
-}
-
-module "level" {
-  source       = "../../rubric_level"
-  rubric_level = var.level
+locals {
+  rubric_category = var.category == null ? null : startswith(var.category, "Z2lkOi8v") ? var.category : element([
+    for category in data.opslevel_rubric_categories.all.rubric_categories :
+    category.id if category.alias == var.category
+  ], 0)
+  rubric_level = var.level == null ? null : startswith(var.level, "Z2lkOi8v") ? var.level : element([
+    for level in data.opslevel_rubric_levels.all.rubric_levels :
+    level.id if level.alias == var.level
+  ], 0)
 }

--- a/modules/rubric_category/data/main.tf
+++ b/modules/rubric_category/data/main.tf
@@ -1,0 +1,1 @@
+data "opslevel_rubric_categories" "all" {}

--- a/modules/rubric_category/data/outputs.tf
+++ b/modules/rubric_category/data/outputs.tf
@@ -1,0 +1,15 @@
+output "all" {
+  value = data.opslevel_rubric_categories.all
+}
+
+output "this" {
+  value = local.requested_category
+}
+
+locals {
+  requested_category = var.rubric_category == null ? null : startswith(var.rubric_category, "Z2lkOi8v") ? var.rubric_category : element([
+    for category in data.opslevel_rubric_categories.all.rubric_categories :
+    category.id if category.alias == var.rubric_category
+  ], 0)
+}
+

--- a/modules/rubric_category/data/variables.tf
+++ b/modules/rubric_category/data/variables.tf
@@ -1,0 +1,5 @@
+variable "rubric_category" {
+  type        = string
+  description = "The id or alias of the category the check belongs to."
+  default     = null
+}

--- a/modules/rubric_category/data/versions.tf
+++ b/modules/rubric_category/data/versions.tf
@@ -1,0 +1,1 @@
+../../versions.tf

--- a/modules/rubric_category/main.tf
+++ b/modules/rubric_category/main.tf
@@ -1,5 +1,3 @@
-data "opslevel_rubric_categories" "all" {}
-
 resource "opslevel_rubric_category" "this" {
   name = var.name
 }

--- a/modules/rubric_category/outputs.tf
+++ b/modules/rubric_category/outputs.tf
@@ -1,7 +1,3 @@
-output "all" {
-  value = data.opslevel_rubric_categories.all
-}
-
 output "this" {
   value = opslevel_rubric_category.this
 }

--- a/modules/rubric_category/outputs.tf
+++ b/modules/rubric_category/outputs.tf
@@ -2,14 +2,6 @@ output "all" {
   value = data.opslevel_rubric_categories.all
 }
 
-# TODO: is this used?
-# output "requested" {
-#   value = var.rubric_category == null ? null : startswith(var.rubric_category, "Z2lkOi8v") ? var.rubric_category : element([
-#     for category in data.opslevel_rubric_categories.all.rubric_categories :
-#     category.id if category.alias == var.rubric_category
-#   ], 0)
-# }
-
 output "this" {
   value = opslevel_rubric_category.this
 }

--- a/modules/rubric_category/variables.tf
+++ b/modules/rubric_category/variables.tf
@@ -2,9 +2,3 @@ variable "name" {
   type        = string
   description = "The display name of the rubric category."
 }
-
-variable "rubric_category" {
-  type        = string
-  description = "The id or alias of the rubric category."
-  default     = null
-}

--- a/modules/rubric_level/data/main.tf
+++ b/modules/rubric_level/data/main.tf
@@ -1,0 +1,1 @@
+data "opslevel_rubric_levels" "all" {}

--- a/modules/rubric_level/data/outputs.tf
+++ b/modules/rubric_level/data/outputs.tf
@@ -1,0 +1,14 @@
+output "all" {
+  value = data.opslevel_rubric_levels.all
+}
+
+output "this" {
+  value = local.requested_level
+}
+
+locals {
+  requested_level = var.rubric_level == null ? null : startswith(var.rubric_level, "Z2lkOi8v") ? var.rubric_level : element([
+    for level in data.opslevel_rubric_levels.all.rubric_levels :
+    level.id if level.alias == var.rubric_level
+  ], 0)
+}

--- a/modules/rubric_level/data/variables.tf
+++ b/modules/rubric_level/data/variables.tf
@@ -1,0 +1,5 @@
+variable "rubric_level" {
+  type        = string
+  description = "The id or alias of the level the check belongs to."
+  default     = null
+}

--- a/modules/rubric_level/data/versions.tf
+++ b/modules/rubric_level/data/versions.tf
@@ -1,0 +1,1 @@
+../../versions.tf

--- a/modules/rubric_level/main.tf
+++ b/modules/rubric_level/main.tf
@@ -1,5 +1,3 @@
-data "opslevel_rubric_levels" "all" {}
-
 resource "opslevel_rubric_level" "this" {
   name        = var.name
   description = var.description

--- a/modules/rubric_level/outputs.tf
+++ b/modules/rubric_level/outputs.tf
@@ -2,14 +2,6 @@ output "all" {
   value = data.opslevel_rubric_levels.all
 }
 
-# TODO: is this used?
-# output "this" {
-#   value = var.rubric_level == null ? null : startswith(var.rubric_level, "Z2lkOi8v") ? var.rubric_level : element([
-#     for level in data.opslevel_rubric_levels.all.rubric_levels :
-#     level.id if level.alias == var.rubric_level
-#   ], 0)
-# }
-
 output "this" {
   value = opslevel_rubric_level.this
 }

--- a/modules/rubric_level/outputs.tf
+++ b/modules/rubric_level/outputs.tf
@@ -1,7 +1,3 @@
-output "all" {
-  value = data.opslevel_rubric_levels.all
-}
-
 output "this" {
   value = opslevel_rubric_level.this
 }

--- a/modules/rubric_level/variables.tf
+++ b/modules/rubric_level/variables.tf
@@ -14,9 +14,3 @@ variable "name" {
   type        = string
   description = "The display name of the rubric level."
 }
-
-variable "rubric_level" {
-  type        = string
-  description = "The id or alias of the rubric level."
-  default     = null
-}


### PR DESCRIPTION
Separate data out from managed resources

- In some cases, we want to use the `rubric_category` module to create and manage an `opslevel_rubric_category`, but don't need to also list all existing categories.
- In other cases, we just want the list of existing `rubric_categories` from the module but the module is expecting to manage a `rubric_category`, so maybe we work around it with `count = var.maybe ? 0 : 1`

Or, we tack on a little `/data` to the end of `source = "../../rubric_level/data"` and set a precedent that `/data` is read-only data wherever we need it