### PR TITLE
Update clear_account.sh

### DIFF
--- a/clear_account.sh
+++ b/clear_account.sh
@@ -61,6 +61,12 @@ echo "$levels" | jq -r '.[] | select(.Index != 0) | .id' | while read -r id; do
   opslevel delete level "$id"
 done
 
+echo "[opslevel] Deleting Filters..."
+filters=$(opslevel list filters -o json)
+echo "$filters" | jq -r '.[] | .Id' | while read -r id; do
+  opslevel delete filter "$id"
+done
+
 echo "[opslevel] Deleting Integrations..."
 integrations=$(opslevel list integrations -o json)
 echo "$integrations" | jq -r '.[] | .id' | while read -r id; do


### PR DESCRIPTION
Resolves #

### Problem

Now that we add filters to the demo account subsequent runs can duplicate filters

### Solution

Clear the demo account of all filters

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] Make a [changie](https://github.com/OpsLevel/opslevel-go/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
